### PR TITLE
feat: add multi-network env configuration for devnet, testnet, and mainnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Environment files with secrets
+.env
+.env.local
+*.db
+
+# IDE
+.idea/
+.vscode/
+
+# OS
+.DS_Store

--- a/frontend/.env.devnet
+++ b/frontend/.env.devnet
@@ -1,0 +1,21 @@
+# CKB-PoP Frontend Environment — Devnet (local node)
+# Usage: vite dev --mode devnet
+
+VITE_CKB_NETWORK=devnet
+VITE_BACKEND_URL=http://localhost:3001/api
+
+# ----- Contract Deployment (fill after deploying to local devnet) -----
+# DOB Badge type script
+VITE_DOB_BADGE_CODE_HASH=
+VITE_DOB_BADGE_HASH_TYPE=data1
+VITE_DOB_BADGE_DEP_TX_HASH=
+VITE_DOB_BADGE_DEP_INDEX=0
+
+# Event Anchor type script
+VITE_EVENT_ANCHOR_CODE_HASH=
+VITE_EVENT_ANCHOR_HASH_TYPE=data1
+VITE_EVENT_ANCHOR_DEP_TX_HASH=
+VITE_EVENT_ANCHOR_DEP_INDEX=0
+
+# Local devnet RPC (used by CCC client)
+VITE_CKB_RPC_URL=http://localhost:8114

--- a/frontend/.env.mainnet
+++ b/frontend/.env.mainnet
@@ -1,0 +1,18 @@
+# CKB-PoP Frontend Environment — Mainnet (Lina/Mirana)
+# Usage: vite dev --mode mainnet  |  vite build --mode mainnet
+
+VITE_CKB_NETWORK=mainnet
+VITE_BACKEND_URL=https://api.ckb-pop.example.com/api
+
+# ----- Contract Deployment (fill after deploying to mainnet) -----
+# DOB Badge type script
+VITE_DOB_BADGE_CODE_HASH=
+VITE_DOB_BADGE_HASH_TYPE=data1
+VITE_DOB_BADGE_DEP_TX_HASH=
+VITE_DOB_BADGE_DEP_INDEX=0
+
+# Event Anchor type script
+VITE_EVENT_ANCHOR_CODE_HASH=
+VITE_EVENT_ANCHOR_HASH_TYPE=data1
+VITE_EVENT_ANCHOR_DEP_TX_HASH=
+VITE_EVENT_ANCHOR_DEP_INDEX=0

--- a/frontend/.env.testnet
+++ b/frontend/.env.testnet
@@ -1,0 +1,18 @@
+# CKB-PoP Frontend Environment — Testnet (Aggron/Pudge)
+# Usage: vite dev --mode testnet  |  vite build --mode testnet
+
+VITE_CKB_NETWORK=testnet
+VITE_BACKEND_URL=http://localhost:3001/api
+
+# ----- Contract Deployment (fill after deploying to testnet) -----
+# DOB Badge type script
+VITE_DOB_BADGE_CODE_HASH=
+VITE_DOB_BADGE_HASH_TYPE=data1
+VITE_DOB_BADGE_DEP_TX_HASH=
+VITE_DOB_BADGE_DEP_INDEX=0
+
+# Event Anchor type script
+VITE_EVENT_ANCHOR_CODE_HASH=
+VITE_EVENT_ANCHOR_HASH_TYPE=data1
+VITE_EVENT_ANCHOR_DEP_TX_HASH=
+VITE_EVENT_ANCHOR_DEP_INDEX=0

--- a/frontend/src/services/wallet.service.ts
+++ b/frontend/src/services/wallet.service.ts
@@ -48,14 +48,32 @@ export interface WalletSuggestion {
   installUrl: string;
 }
 
+// Select CKB client based on VITE_CKB_NETWORK environment variable
+function createCkbClient(): ccc.Client {
+  const network = import.meta.env?.VITE_CKB_NETWORK || 'testnet';
+  switch (network) {
+    case 'mainnet':
+      return new ccc.ClientPublicMainnet();
+    case 'devnet': {
+      const rpcUrl = import.meta.env?.VITE_CKB_RPC_URL || 'http://localhost:8114';
+      return new ccc.ClientPublicTestnet({ url: rpcUrl });
+    }
+    case 'testnet':
+    default:
+      return new ccc.ClientPublicTestnet();
+  }
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class WalletService {
   private toast = inject(ToastService);
 
-  // CKB Client - using testnet for development
-  private client = new ccc.ClientPublicTestnet();
+  // CKB Client — network selected via VITE_CKB_NETWORK env var
+  private client = createCkbClient();
+
+  readonly network = import.meta.env?.VITE_CKB_NETWORK || 'testnet';
 
   // Custom signers controller for wallet discovery
   private signersController = new CustomSignersController();

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,6 +1,9 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_CKB_NETWORK?: 'devnet' | 'testnet' | 'mainnet';
+  readonly VITE_CKB_RPC_URL?: string;
+  readonly VITE_BACKEND_URL?: string;
   readonly VITE_DOB_BADGE_CODE_HASH?: string;
   readonly VITE_DOB_BADGE_HASH_TYPE?: string;
   readonly VITE_DOB_BADGE_DEP_TX_HASH?: string;

--- a/scripts/.env.devnet
+++ b/scripts/.env.devnet
@@ -1,0 +1,3 @@
+# CKB-PoP Backend — Devnet (local node)
+CKB_RPC_URL=http://localhost:8114
+DATABASE_URL=sqlite:ckb_pop_dev.db

--- a/scripts/.env.mainnet
+++ b/scripts/.env.mainnet
@@ -1,0 +1,3 @@
+# CKB-PoP Backend — Mainnet
+CKB_RPC_URL=https://mainnet.ckb.dev/rpc
+DATABASE_URL=sqlite:ckb_pop.db

--- a/scripts/.env.testnet
+++ b/scripts/.env.testnet
@@ -1,0 +1,3 @@
+# CKB-PoP Backend — Testnet
+CKB_RPC_URL=https://testnet.ckb.dev/rpc
+DATABASE_URL=sqlite:ckb_pop.db

--- a/scripts/src/main.rs
+++ b/scripts/src/main.rs
@@ -23,8 +23,17 @@ async fn main() {
 
     dotenvy::dotenv().ok();
 
+    // Load network-specific env file: .env.testnet, .env.mainnet, or .env.devnet
+    let ckb_network = std::env::var("CKB_NETWORK").unwrap_or_else(|_| "testnet".to_string());
+    let env_file = format!(".env.{}", ckb_network);
+    if let Err(_) = dotenvy::from_filename(&env_file) {
+        tracing::warn!("No {} found, using defaults for {}", env_file, ckb_network);
+    }
+
     let database_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite:ckb_pop.db".to_string());
     let ckb_rpc_url = std::env::var("CKB_RPC_URL").unwrap_or_else(|_| "https://testnet.ckb.dev/rpc".to_string());
+
+    tracing::info!("Network: {}, RPC: {}", ckb_network, ckb_rpc_url);
 
     let state = AppState::new(&database_url, &ckb_rpc_url)
         .await


### PR DESCRIPTION
This pull request adds multi-network environment support for both the frontend and backend, allowing seamless switching between devnet, testnet, and mainnet configurations. It introduces network-specific environment files, updates client initialization logic to respect the selected network, and improves backend startup to load the appropriate environment file based on the network.

**Frontend environment and client selection:**

* Added `.env.devnet`, `.env.testnet`, and `.env.mainnet` files in `frontend/` to define network-specific environment variables for devnet, testnet, and mainnet, including contract deployment placeholders and backend URLs. [[1]](diffhunk://#diff-ce6d9ce806285426c8c920d8483802699abcab9389f06bdbe20f1f51763d09b2R1-R21) [[2]](diffhunk://#diff-ee1ef8b3d0e3ed62cfdaa0fc2151056c7d61a611d8b6089329dd7422619a6c85R1-R18) [[3]](diffhunk://#diff-34919327ff3a5c83e3461148803480d89eed1bf01ffcf1f45ede289deacbeb4cR1-R18)
* Updated `WalletService` in `frontend/src/services/wallet.service.ts` to initialize the CKB client based on the `VITE_CKB_NETWORK` environment variable, supporting mainnet, devnet, and testnet.

**Backend environment and startup logic:**

* Added `.env.devnet`, `.env.testnet`, and `.env.mainnet` files in `scripts/` to configure backend database and RPC URLs for each network. [[1]](diffhunk://#diff-e71aadba40e575d88a116dd087013d76ee8228b110be229f50a49d9f023fa76bR1-R3) [[2]](diffhunk://#diff-8d465d8e78ef12c752fc1ff06d7ba558b0dee00e6224afc028e8059b1c4102eaR1-R3) [[3]](diffhunk://#diff-06eb933ba1acb3b9f9da159970d97e0edde2cfa2b9a0672d574ae879a7a7b1e4R1-R3)
* Modified backend startup in `scripts/src/main.rs` to load the appropriate `.env.<network>` file based on the `CKB_NETWORK` environment variable, with improved logging for network and RPC selection.