### PR TITLE
Fix: Replace fake or simulated blocks with real blocks from real chain data

### DIFF
--- a/frontend/src/components/gallery/gallery.component.ts
+++ b/frontend/src/components/gallery/gallery.component.ts
@@ -426,20 +426,24 @@ export class GalleryComponent implements OnInit {
   constructor() {
     effect(() => {
       if (this.walletService.isConnected()) {
-        this.simulateLoad();
+        this.loadBadges();
       }
     });
   }
 
   ngOnInit() {
     if (this.walletService.isConnected()) {
-      this.simulateLoad();
+      this.loadBadges();
     }
   }
 
-  private simulateLoad() {
+  private async loadBadges() {
     this.loading.set(true);
-    setTimeout(() => this.loading.set(false), 400);
+    const address = this.walletService.address();
+    if (address) {
+      await this.poapService.loadBadgesFromBackend(address);
+    }
+    this.loading.set(false);
   }
 
   truncateAddress(address: string | null, start: number, end: number): string {
@@ -469,8 +473,9 @@ export class GalleryComponent implements OnInit {
   }
 
   getBlockNumber(badge: Badge): string {
-    const hash = badge.txHash;
-    const num = parseInt(hash.slice(2, 10), 16) % 20000000 + 10000000;
-    return num.toLocaleString();
+    if (badge.blockNumber != null) {
+      return badge.blockNumber.toLocaleString();
+    }
+    return 'Pending';
   }
 }


### PR DESCRIPTION
This pull request updates the badge and event loading logic in the frontend to fetch real data from the backend instead of using simulated/demo data. The changes improve data accuracy, enhance the user experience, and ensure that badge and event information is always up-to-date. The most important changes are grouped below.

**Backend Integration and Data Loading:**

* Replaced the previous simulated badge loading in `GalleryComponent` with a new `loadBadges` method that fetches badges from the backend for the connected wallet address, ensuring users see their actual badges. (`gallery.component.ts`)
* Added the `loadBadgesFromBackend` method in `PoapService` to fetch badges for a given address, merge them with any locally minted badges, and update the signal accordingly. (`poap.service.ts`)
* Updated event fetching logic in `PoapService` to always attempt to retrieve event details from the backend, removing legacy/demo fallback data and ensuring event information is accurate. (`poap.service.ts`)

**Badge Data Model and Display:**

* Extended the `Badge` interface to include an optional `blockNumber` property, allowing the UI to display the actual block number for each badge. (`poap.service.ts`)
* Updated the badge block number display logic in `GalleryComponent` to show the real block number if available, or 'Pending' if not, instead of generating a pseudo-random number from the transaction hash. (`gallery.component.ts`)

**Cleanup and Removal of Demo Data:**

* Removed all demo/simulated badge and attendee data from `PoapService`, so all badge and attendee information now comes from the backend or local minting actions. (`poap.service.ts`) [[1]](diffhunk://#diff-a8a9a78ddf853cca5f9a500f7dddecaa837d7b5e496c7357536e91e22a3485efL43-R44) [[2]](diffhunk://#diff-a8a9a78ddf853cca5f9a500f7dddecaa837d7b5e496c7357536e91e22a3485efR187-R201)

These changes collectively ensure that badge and event data shown to users is accurate, up-to-date, and consistent with the backend source of truth.